### PR TITLE
Use walker route param when loading profile

### DIFF
--- a/src/pages/WalkerProfile.js
+++ b/src/pages/WalkerProfile.js
@@ -5,7 +5,8 @@ import { vibrate } from '../utils/helpers';
 
 const WalkerProfile = () => {
     const navigate = useNavigate();
-    const { walkerId } = useParams();
+    const { id } = useParams();
+    const walkerId = id;
     const [searchParams] = useSearchParams();
     const backTarget = searchParams.get('back') || 'home';
     const { getWalkerById, toggleWalkerFavorite } = useAppContext();


### PR DESCRIPTION
## Summary
- read the walker id from the route parameter named `id`
- use the normalized walker id when loading data and toggling favorites so profiles open correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddede2b87c832f9b888bc24273ec62