### PR TITLE
Fix walker favorite toggling state

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
-import { dogData as initialDogs, walkerData, walkHistoryData as initialWalkHistory, recurringWalkPlans as initialRecurringPlans, inboxData, chatData, paymentData, userProfile as initialUserProfile } from '../data/mockData';
+import { dogData as initialDogs, walkerData as initialWalkers, walkHistoryData as initialWalkHistory, recurringWalkPlans as initialRecurringPlans, inboxData, chatData, paymentData, userProfile as initialUserProfile } from '../data/mockData';
 
 const AppContext = createContext();
 
@@ -13,6 +13,7 @@ export const useAppContext = () => {
 
 export const AppProvider = ({ children }) => {
     const [dogs, setDogs] = useState(initialDogs);
+    const [walkers, setWalkers] = useState(initialWalkers);
     const [walkHistory, setWalkHistory] = useState(initialWalkHistory);
     const [recurringPlans, setRecurringPlans] = useState(initialRecurringPlans);
     const [userProfile, setUserProfile] = useState(initialUserProfile);
@@ -115,14 +116,19 @@ export const AppProvider = ({ children }) => {
 
     // Walker management
     const toggleWalkerFavorite = (walkerId) => {
-        const walker = walkerData.find(w => w.id === walkerId);
-        if (walker) {
-            walker.favorite = !walker.favorite;
-        }
+        const numericId = typeof walkerId === 'string' ? parseInt(walkerId, 10) : walkerId;
+        setWalkers(prevWalkers =>
+            prevWalkers.map(walker =>
+                walker.id === numericId
+                    ? { ...walker, favorite: !walker.favorite }
+                    : walker
+            )
+        );
     };
 
     const getWalkerById = (id) => {
-        return walkerData.find(w => w.id === parseInt(id));
+        const numericId = typeof id === 'string' ? parseInt(id, 10) : id;
+        return walkers.find(w => w.id === numericId);
     };
 
     // User profile management
@@ -133,7 +139,7 @@ export const AppProvider = ({ children }) => {
     const value = {
         // Data
         dogs,
-        walkerData,
+        walkerData: walkers,
         walkHistory,
         recurringPlans,
         inboxData,

--- a/src/pages/WalkerProfile.js
+++ b/src/pages/WalkerProfile.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAppContext } from '../context/AppContext';
 import { vibrate } from '../utils/helpers';
@@ -12,7 +12,6 @@ const WalkerProfile = () => {
     const { getWalkerById, toggleWalkerFavorite } = useAppContext();
 
     const walker = getWalkerById(walkerId);
-    const [isFavorite, setIsFavorite] = useState(walker?.favorite || false);
 
     const handleBack = () => {
         vibrate();
@@ -25,8 +24,10 @@ const WalkerProfile = () => {
 
     const handleFavoriteToggle = () => {
         vibrate();
-        toggleWalkerFavorite(parseInt(walkerId));
-        setIsFavorite(!isFavorite);
+        if (!walker) {
+            return;
+        }
+        toggleWalkerFavorite(walkerId);
     };
 
     if (!walker) {
@@ -43,8 +44,9 @@ const WalkerProfile = () => {
                 </button>
                 <h1>Walker Profile</h1>
                 <button
-                    className={`favorite-btn p-2 ${isFavorite ? 'favorited' : ''}`}
+                    className={`favorite-btn p-2 ${walker?.favorite ? 'favorited' : ''}`}
                     onClick={handleFavoriteToggle}
+                    aria-pressed={walker?.favorite ?? false}
                 >
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none">
                         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>


### PR DESCRIPTION
## Summary
- manage walker data through React state so favorite toggles propagate updates to consumers
- update walker profile to read favorite status from context and expose accessible toggle state

## Testing
- CI=true npm test -- --watch=false *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ddf16d0420832fb2fed32e05e5d945